### PR TITLE
Fixed fib.ts by correctly assigning the 'n' variable to be a number

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
This PR fixes a type safety issue in fib.ts by adding a : number type annotation to the n parameter of the fib function, which was previously implicitly any. This change ensures the function is properly type-checked to prevent bugs from non-number inputs and will close the related issue by enforcing compile-time safety and improving code clarity.