### PR TITLE
Fixed fib.ts by correctly assigning the 'n' variable to be a number

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
This PR fixes a type safety issue in fib.ts by adding a : number type annotation to the n parameter of the fib function. Previously, the lack of an explicit type meant it was implicitly any, which defeats the purpose of TypeScript and could allow non-number inputs to cause runtime errors. This change ensures the function is properly type-checked at compile time, preventing potential bugs and improving code clarity and IntelliSense.

This change is being merged from the main branch into a feature branch that was intended to already include this fix. Syncing this correction now ensures both branches remain aligned and prevents this type safety issue from being reintroduced into the main codebase during the eventual merge.